### PR TITLE
[RFC] Move to Ubuntu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ env:
 
 matrix:
   include:
-    - name: "Debian"
-      env: BASE=debian REPO=clangbuiltlinux/${BASE}
+    - name: "Ubuntu"
+      env: BASE=ubuntu REPO=clangbuiltlinux/${BASE}
 
 services:
   - docker

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ClangBuiltLinux Docker image
 
-This repo holds the files for [the ClangBuiltLinux Docker organization](https://hub.docker.com/r/clangbuiltlinux/). This allows us to have a consistent environment for our continuous integration, as well as getting other developers involved. It is based on Debian unstable and includes the nightly builds of Clang and lld from apt.llvm.org and binutils/QEMU for arm, arm64, powerpc, and x86_64.
+This repo holds the files for [the ClangBuiltLinux Docker organization](https://hub.docker.com/r/clangbuiltlinux/). This allows us to have a consistent environment for our continuous integration, as well as getting other developers involved. It is based on the latest Ubuntu image and includes the nightly builds of Clang and lld from apt.llvm.org and binutils/QEMU for arm, arm64, powerpc, and x86_64.
 
-Currently, this image is available for x86_64 hosts on [Docker Hub](https://hub.docker.com/r/clangbuiltlinux/debian/) (`docker run -ti clangbuiltlinux/debian`), which is updated daily via a Travis cron.
+Currently, this image is available for x86_64 hosts on [Docker Hub](https://hub.docker.com/r/clangbuiltlinux/ubuntu/) (`docker run -ti clangbuiltlinux/ubuntu`), which is updated daily via a Travis cron.
 
 If you do not have an x86_64 system but would like to have access to this image, you can still clone this repo and build the image via `docker build -t clangbuiltlinux/debian .`
 
@@ -12,4 +12,4 @@ Once you have started running this image, you will have the full set of tools ne
 
 ## Pushing a new image manually
 
-Travis handles pushing images when new commits are added to the repo and daily via a cron. However, if the images need to be refreshed manually and you have been given access to push new images to Docker Hub, you can push the image by building it via `docker build -t clangbuiltlinux/debian:$(date +%Y%m%d) -t clangbuiltlinux/debian:latest .` then `DOCKER_USERNAME=<your_username> DOCKER_PASSWORD=<your_password> ./deploy.sh`
+Travis handles pushing images when new commits are added to the repo and daily via a cron. However, if the images need to be refreshed manually and you have been given access to push new images to Docker Hub, you can push the image by building it via `docker build -t clangbuiltlinux/ubuntu:$(date +%Y%m%d) -t clangbuiltlinux/ubuntu:latest .` then `DOCKER_USERNAME=<your_username> DOCKER_PASSWORD=<your_password> ./deploy.sh`


### PR DESCRIPTION
@tpimh had suggested this here: https://github.com/ClangBuiltLinux/continuous-integration/issues/34#issuecomment-441559837

It shrinks the image slightly (263 MB -> 229 MB) and avoids building binaries from source during the packaging process. While a non-x86 host still could not run the image generated from this Dockerfile because the builds of Clang from apt.llvm.org are for x86 hosts only, we're one step closer because we use .deb packages for everything.

Verification run: https://travis-ci.com/nathanchance/continuous-integration/builds/92515400

I've labelled this as RFC because I'm not married to the idea of switching distro bases but it does have its benefits so it's worth discussing.