### PR TITLE
Dockerfile: Make sure binaries are executable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,8 @@ RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
         skiboot \
         qemu-system-arm \
         qemu-system-ppc \
-        qemu-system-x86
+        qemu-system-x86 && \
+    chmod -f +x /usr/lib/llvm-8/bin/*
 
 # Add a function to easily clone torvalds/linux, linux-next, and linux-stable
 COPY clone_tree /root


### PR DESCRIPTION
Fixes the following fail: https://travis-ci.com/ClangBuiltLinux/dockerimage/builds/94584251

@dileks Do you know if the Debian package maintainer is also responsible for the Ubuntu packages since you have been in contact with him? This appears to be fixed within Debian on the clang-7 branch: https://salsa.debian.org/pkg-llvm-team/llvm-toolchain/commit/fd33d6731cf107f2e3e6b2a886dc33ac5153b359