### PR TITLE
travis: Make sure lld is executable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ services:
 script:
   - docker build -t ${REPO}:${TAG} -t ${REPO}:latest .
   - docker run --rm -ti ${REPO}:${TAG} clang-8 --version
+  - docker run --rm -ti ${REPO}:${TAG} ld.lld-8 --version
   - docker run --rm -ti ${REPO}:${TAG} qemu-system-x86_64 --version
   - docker run --rm -ti ${REPO}:${TAG} qemu-system-ppc --version
 


### PR DESCRIPTION
Our arm64 builds were failing for a bit because lld was not executable.
We didn't notice until clang-8 wasn't executable. Avoid this in the
future.

https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/164837632