### PR TITLE
Dockerfile: Add u-boot-tools for mkimage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get update -qq && \
         libssl-dev \
         make \
         openssl \
+        u-boot-tools \
         xz-utils
 
 # Install the latest nightly Clang/lld packages from apt.llvm.org and QEMU packages from Joel Stanley's PPA


### PR DESCRIPTION
This is required by the ppc32 kernel build. Note that it should not be
necessary, as we do not need the wrapped image.

I opened an issue to fix this: https://github.com/linuxppc/linux/issues/211

Signed-off-by: Joel Stanley <joel@jms.id.au>