### PR TITLE
Docker: Move back to Debian testing

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-# Use the latest Ubuntu image as the base
-FROM ubuntu:rolling
+# Use the latest slim Debian testing image as the base
+FROM debian:testing-slim
 
 # Make sure that all packages are up to date then
-# install the base Ubuntu packages that we need for
+# install the base Debian packages that we need for
 # building the kernel
 RUN apt-get update -qq && \
     apt-get upgrade -y && \
-    ln -snf /usr/share/zoneinfo/UTC /etc/localtime && echo "UTC" > /etc/timezone && \
     apt-get install --no-install-recommends -y \
         bc \
         binutils \
@@ -27,23 +26,21 @@ RUN apt-get update -qq && \
         libssl-dev \
         make \
         openssl \
+        qemu-skiboot \
+        qemu-system-arm \
+        qemu-system-ppc \
+        qemu-system-x86 \
         u-boot-tools \
         xz-utils
 
-# Install the latest nightly Clang/lld packages from apt.llvm.org and QEMU packages from Joel Stanley's PPA
+# Install the latest nightly Clang/lld packages from apt.llvm.org
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic main" | tee -a /etc/apt/sources.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E007EC6A && \
-    echo "deb http://ppa.launchpad.net/shenki/ppa/ubuntu cosmic main" | tee -a /etc/apt/sources.list && \
+    echo "deb http://apt.llvm.org/unstable/ llvm-toolchain main" | tee -a /etc/apt/sources.list && \
     apt-get update -qq && \
     apt-get install --no-install-recommends -y \
         clang-9 \
         lld-9 \
-        llvm-9 \
-        qemu-skiboot \
-        qemu-system-arm \
-        qemu-system-ppc \
-        qemu-system-x86 && \
+        llvm-9 && \
     chmod -f +x /usr/lib/llvm-9/bin/*
 
 # Add a function to easily clone torvalds/linux, linux-next, and linux-stable

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DATE ?= $(shell date +%Y%m%d)
 DOCKER ?= docker
-REPO ?= clangbuiltlinux/ubuntu
+REPO ?= clangbuiltlinux/debian
 
 image:
 	@$(DOCKER) build -t $(REPO):latest .

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # ClangBuiltLinux Docker image
 
-This repo holds the files for [the ClangBuiltLinux Docker organization](https://hub.docker.com/r/clangbuiltlinux/). This allows us to have a consistent environment for our continuous integration, as well as getting other developers involved. It is based on the latest Ubuntu image and includes the nightly builds of Clang and lld from apt.llvm.org and binutils/QEMU for arm, arm64, powerpc, and x86_64.
+This repo holds the files for [the ClangBuiltLinux Docker organization](https://hub.docker.com/r/clangbuiltlinux/). This allows us to have a consistent environment for our continuous integration, as well as getting other developers involved. It is based on the latest Debian unstable image and includes the nightly builds of Clang and lld from apt.llvm.org and binutils/QEMU for arm, arm64, powerpc, and x86_64.
 
-Currently, this image is available for x86_64 hosts on [Docker Hub](https://hub.docker.com/r/clangbuiltlinux/ubuntu/) (`docker run -ti clangbuiltlinux/ubuntu`), which is updated daily via a Travis cron.
+Currently, this image is available for x86_64 hosts on [Docker Hub](https://hub.docker.com/r/clangbuiltlinux/debian/) (`docker run -ti clangbuiltlinux/debian`), which is updated daily via a Travis cron.
 
 We are thinking of ways to make this image available to other architectures. The biggest blocker is the nightly Clang builds are only for x86.
 


### PR DESCRIPTION
Now that QEMU has been updated to 3.1, which includes the fix for
https://github.com/ClangBuiltLinux/continuous-integration/issues/16#issuecomment-436149899.

This effectively reverts #9.

I've done a few local builds without any regressions.