### PR TITLE
Docker: Allow building images with different versions of LLVM/Clang

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,13 @@ language: c
 services:
   - docker
 
+matrix:
+  include:
+    - name: "Development"
+      env: LLVM_VERSION=9
+    - name: "Stable"
+      env: LLVM_VERSION=8
+
 script:
   - make release
   - make check

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 # Use the latest slim Debian testing image as the base
 FROM debian:testing-slim
 
+# Default to the development branch of LLVM (currently 9)
+# User can override this to a stable branch (like 7 or 8)
+ARG LLVM_VERSION=9
+
 # Make sure that all packages are up to date then
 # install the base Debian packages that we need for
 # building the kernel
@@ -35,13 +39,13 @@ RUN apt-get update -qq && \
 
 # Install the latest nightly Clang/lld packages from apt.llvm.org
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/unstable/ llvm-toolchain main" | tee -a /etc/apt/sources.list && \
+    echo "deb http://apt.llvm.org/unstable/ llvm-toolchain$(test ${LLVM_VERSION} -ne 9 && echo "-${LLVM_VERSION}") main" | tee -a /etc/apt/sources.list && \
     apt-get update -qq && \
     apt-get install --no-install-recommends -y \
-        clang-9 \
-        lld-9 \
-        llvm-9 && \
-    chmod -f +x /usr/lib/llvm-9/bin/*
+        clang-${LLVM_VERSION} \
+        lld-${LLVM_VERSION} \
+        llvm-${LLVM_VERSION} && \
+    chmod -f +x /usr/lib/llvm-${LLVM_VERSION}/bin/*
 
 # Add a function to easily clone torvalds/linux, linux-next, and linux-stable
 COPY clone_tree /root

--- a/Makefile
+++ b/Makefile
@@ -1,28 +1,35 @@
 DATE ?= $(shell date +%Y%m%d)
 DOCKER ?= docker
+LLVM_VERSION ?= 9
+LATEST_TAG := llvm$(LLVM_VERSION)-latest
 REPO ?= clangbuiltlinux/debian
 
+TAG_FLAGS := -t $(REPO):$(LATEST_TAG)
+ifeq ($(LLVM_VERSION),9)
+TAG_FLAGS := $(TAG_FLAGS) -t $(REPO):latest
+endif
+
 image:
-	@$(DOCKER) build -t $(REPO):latest .
+	@$(DOCKER) build $(TAG_FLAGS) --build-arg LLVM_VERSION=$(LLVM_VERSION) .
 
 release:
-	@$(DOCKER) build -t $(REPO):$(DATE) -t $(REPO):latest .
+	@$(DOCKER) build -t $(REPO):llvm$(LLVM_VERSION)-$(DATE) $(TAG_FLAGS) --build-arg LLVM_VERSION=$(LLVM_VERSION) .
 
 check:
-	$(DOCKER) run --rm -ti $(REPO):latest clang-9 --version
+	$(DOCKER) run --rm -ti $(REPO):$(LATEST_TAG) clang-$(LLVM_VERSION) --version
 	@echo
-	$(DOCKER) run --rm -ti $(REPO):latest ld.lld-9 --version
+	$(DOCKER) run --rm -ti $(REPO):$(LATEST_TAG) ld.lld-$(LLVM_VERSION) --version
 	@echo
-	$(DOCKER) run --rm -ti $(REPO):latest qemu-system-arm --version
+	$(DOCKER) run --rm -ti $(REPO):$(LATEST_TAG) qemu-system-arm --version
 	@echo
-	$(DOCKER) run --rm -ti $(REPO):latest qemu-system-aarch64 --version
+	$(DOCKER) run --rm -ti $(REPO):$(LATEST_TAG) qemu-system-aarch64 --version
 	@echo
-	$(DOCKER) run --rm -ti $(REPO):latest qemu-system-x86_64 --version
+	$(DOCKER) run --rm -ti $(REPO):$(LATEST_TAG) qemu-system-x86_64 --version
 	@echo
-	$(DOCKER) run --rm -ti $(REPO):latest qemu-system-ppc --version
+	$(DOCKER) run --rm -ti $(REPO):$(LATEST_TAG) qemu-system-ppc --version
 
 deploy:
-	@REPO=$(REPO) DATE=$(DATE) bash deploy.sh
+	@REPO=$(REPO) DATE=$(DATE) LLVM_VERSION=$(LLVM_VERSION) bash deploy.sh
 
 help:
 	@echo

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 set -eux
 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-docker push ${REPO}:${DATE}
-docker push ${REPO}:latest
+docker push ${REPO}:llvm${LLVM_VERSION:=9}-${DATE}
+docker push ${REPO}:llvm${LLVM_VERSION}-latest
+if [[ ${LLVM_VERSION} -eq 9 ]]; then
+    docker push ${REPO}:latest
+fi


### PR DESCRIPTION
As suggested by @shenki in #21, allow images to be built with the stable version of LLVM/Clang so we can get a little bit more coverage.

The commit messages should explain all of the logic but I'm happy to answer any questions.

Closes #21.

I will wire this up into continuous integration after this is merged (because this will not break the current CI setup).