### PR TITLE
Dockerfile: Fail the build when clang has not been updated in five days

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,12 @@ RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
         llvm-${LLVM_VERSION} && \
     chmod -f +x /usr/lib/llvm-${LLVM_VERSION}/bin/*
 
+# Check and see Clang has not been rebuilt in more than five days if we are on the master branch and fail the build if so
+# We copy, execute, then remove because it is not necessary to carry this script in the image once it's built
+COPY clang-check.sh /
+RUN bash /clang-check.sh && \
+    rm /clang-check.sh
+
 # Add a function to easily clone torvalds/linux, linux-next, and linux-stable
 COPY clone_tree /root
 RUN cat /root/clone_tree >> /root/.bashrc && \

--- a/clang-check.sh
+++ b/clang-check.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# We only want this check to run on the master branch of LLVM
+if [[ ${LLVM_VERSION} -eq 9 ]]; then
+    # The format of clang --version with apt.llvm.org builds looks like:
+    # $ clang-9 --version
+    # clang version 9.0.0-svn356030-1~exp1+0~20190313082415.405~1.gbp505100 (trunk)
+    # Target: x86_64-pc-linux-gnu
+    # Thread model: posix
+    # InstalledDir: /usr/bin
+    CLANG_DATE=$(clang-${LLVM_VERSION} --version | head -n1 | cut -d '~' -f 3 | cut -d . -f 1)
+
+    # Next, we need to parse the date into a format the date binary can understand
+    # We use bash substring expansion: https://wiki.bash-hackers.org/syntax/pe#substring_expansion
+    CLANG_DATE="${CLANG_DATE:0:4}-${CLANG_DATE:4:2}-${CLANG_DATE:6:2} ${CLANG_DATE:8:2}:${CLANG_DATE:10:2}:${CLANG_DATE:12:2}"
+
+    # Calculate the seconds between now and when Clang was built
+    # 'date -u' ensures that we get an accurate measurement because clang's date is in UTC
+    SECONDS_BETWEEN=$(($(date -u +%s) - $(date -u -d "${CLANG_DATE:?}" +%s)))
+
+    # Then convert that to days
+    DAYS_SINCE=$((SECONDS_BETWEEN / 86400))
+
+    # Error out if DAYS_SINCE is greater than five days
+    if [[ ${DAYS_SINCE} -ge 5 ]]; then
+        echo
+        echo "clang-${LLVM_VERSION} hasn't been updated in ${DAYS_SINCE} days!"
+        echo
+        exit 1
+    fi
+fi
+
+# Explicitly exit with a zero exit status so 'docker build' continues
+exit 0


### PR DESCRIPTION
I think this should be done here instead of in `driver.sh` for a few reasons:

1. Users of `driver.sh` should not penalized.

2. We can only count on apt.llvm.org builds to have the build date in the version string.

3. CI can continue to work as we will have a pinned build that is hopefully stable.