### PR TITLE
Dockerfile: Removing apt cache after the first install cleans up another 17mb in the final image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,8 @@ RUN apt-get update -qq && \
         qemu-system-ppc \
         qemu-system-x86 \
         u-boot-tools \
-        xz-utils
+        xz-utils && \
+    rm -rf /var/lib/apt/lists/*
 
 # Install the latest nightly Clang/lld packages from apt.llvm.org
 # Delete all the apt list files since they're big and get stale quickly


### PR DESCRIPTION
Dockerfile: Removing apt cache after the first install cleans up another 17mb in the final image.

It really doesn't matter really, but it's semantics