### PR TITLE
Dockerfile: Install cpio

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update -qq && \
         bison \
         ca-certificates \
         ccache \
+        cpio \
         curl \
         expect \
         flex \


### PR DESCRIPTION
This is needed to fix failures like https://travis-ci.com/ClangBuiltLinux/continuous-integration/jobs/279238951.