### PR TITLE
RISC-V binutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -qq && \
         binutils-powerpc-linux-gnu \
         binutils-powerpc64-linux-gnu \
         binutils-powerpc64le-linux-gnu \
+        binutils-riscv64-linux-gnu \
         binutils-s390x-linux-gnu \
         bison \
         ca-certificates \

--- a/scripts/check-binaries.sh
+++ b/scripts/check-binaries.sh
@@ -22,7 +22,7 @@ done
 
 BINUTILS_PREFIXES=( "" "aarch64-linux-gnu-" "arm-linux-gnueabi-" "mips-linux-gnu-"
                     "mipsel-linux-gnu-" "powerpc-linux-gnu-" "powerpc64-linux-gnu-"
-                    "powerpc64le-linux-gnu-" "s390x-linux-gnu-" )
+                    "powerpc64le-linux-gnu-" "riscv64-linux-gnu-" "s390x-linux-gnu-" )
 for BINUTILS_PREFIX in "${BINUTILS_PREFIXES[@]}"; do
     test_command "${BINUTILS_PREFIX}as"
 done


### PR DESCRIPTION
A little improvement on  #30 by @martell, only adding binutils for now, qemu will be added when we start boot testing.