### PR TITLE
Dockerfile: Upgrade to Debian unstable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the latest slim Debian stable image as the base
-FROM debian:stable-slim
+# Use the latest slim Debian unstable image as the base
+FROM debian:unstable-slim
 
 # Default to the development branch of LLVM (currently 11)
 # User can override this to a stable branch (like 9 or 10)
@@ -50,7 +50,7 @@ RUN apt-get update -qq && \
 # Install the latest nightly Clang/lld packages from apt.llvm.org
 # Delete all the apt list files since they're big and get stale quickly
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster$(test ${LLVM_VERSION} -ne 11 && echo "-${LLVM_VERSION}") main" | tee -a /etc/apt/sources.list && \
+    echo "deb http://apt.llvm.org/unstable/ llvm-toolchain$(test ${LLVM_VERSION} -ne 11 && echo "-${LLVM_VERSION}") main" | tee -a /etc/apt/sources.list && \
     apt-get update -qq && \
     apt-get install --no-install-recommends -y \
         clang-${LLVM_VERSION} \


### PR DESCRIPTION
We need Debian unstable to get access to QEMU 4.2.0, which fixes a
PowerPC hang (ClangBuiltLinux/continuous-integration#262).

I ran this through `make image check` locally, where it passed
`./build-all.sh` from the CI repo.