### PR TITLE
Dockerfile: Replace qemu-skiboot with qemu-system-common

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,8 +37,8 @@ RUN apt-get update -qq && \
         openssl \
         ovmf \
         qemu-efi-aarch64 \
-        qemu-skiboot \
         qemu-system-arm \
+        qemu-system-common \
         qemu-system-mips \
         qemu-system-ppc \
         qemu-system-x86 \


### PR DESCRIPTION
This package is now a virtual package for qemu-system-data, which is
replaced by qemu-system-common:

https://packages.debian.org/sid/qemu-skiboot
https://packages.debian.org/sid/qemu-system-data
https://travis-ci.com/github/nathanchance/dockerimage/jobs/319374967

Ultimately, we do not need the skiboot image from Debian because our
boot-utils repo provides its own version to work with newer QEMU
versions. Just install the qemu-system-common so that our image builds
properly.