### PR TITLE
dockerimage: Move to Ubuntu Focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-# Use the latest slim Debian unstable image as the base
-FROM debian:unstable-slim
+# Use the latest Ubuntu Focal (20.04 LTS) image as the base
+FROM ubuntu:focal
 
 # Default to the development branch of LLVM (currently 11)
 # User can override this to a stable branch (like 9 or 10)
 ARG LLVM_VERSION=11
 
 # Make sure that all packages are up to date then
-# install the base Debian packages that we need for
+# install the base Ubuntu packages that we need for
 # building the kernel
 RUN apt-get update -qq && \
-    apt-get upgrade -y && \
-    apt-get install --no-install-recommends -y \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install --no-install-recommends -y \
         bc \
         binutils \
         binutils-aarch64-linux-gnu \
@@ -38,7 +38,6 @@ RUN apt-get update -qq && \
         ovmf \
         qemu-efi-aarch64 \
         qemu-system-arm \
-        qemu-system-common \
         qemu-system-mips \
         qemu-system-ppc \
         qemu-system-x86 \
@@ -50,7 +49,7 @@ RUN apt-get update -qq && \
 # Install the latest nightly Clang/lld packages from apt.llvm.org
 # Delete all the apt list files since they're big and get stale quickly
 RUN curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
-    echo "deb http://apt.llvm.org/unstable/ llvm-toolchain$(test ${LLVM_VERSION} -ne 11 && echo "-${LLVM_VERSION}") main" | tee -a /etc/apt/sources.list && \
+    echo "deb http://apt.llvm.org/focal/ llvm-toolchain-focal$(test ${LLVM_VERSION} -ne 11 && echo "-${LLVM_VERSION}") main" | tee -a /etc/apt/sources.list && \
     apt-get update -qq && \
     apt-get install --no-install-recommends -y \
         clang-${LLVM_VERSION} \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ DATE ?= $(shell date +%Y%m%d)
 DOCKER ?= docker
 LLVM_VERSION ?= 11
 LATEST_TAG := llvm$(LLVM_VERSION)-latest
-REPO ?= clangbuiltlinux/debian
+REPO ?= clangbuiltlinux/ubuntu
 
 TAG_FLAGS := -t $(REPO):$(LATEST_TAG)
 ifeq ($(LLVM_VERSION),11)

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![Build Status](https://api.travis-ci.com/ClangBuiltLinux/dockerimage.svg?branch=master)](https://api.travis-ci.com/ClangBuiltLinux/dockerimage.svg?branch=master)
 
-This repo holds the files for [the ClangBuiltLinux Docker organization](https://hub.docker.com/r/clangbuiltlinux/). This allows us to have a consistent environment for our continuous integration, as well as getting other developers involved. It is based on the latest Debian unstable image and includes the nightly builds of Clang and lld from apt.llvm.org and binutils/QEMU for arm, arm64, powerpc, and x86_64.
+This repo holds the files for [the ClangBuiltLinux Docker organization](https://hub.docker.com/r/clangbuiltlinux/). This allows us to have a consistent environment for our continuous integration, as well as getting other developers involved. It is based on the latest Ubuntu Focal image and includes the nightly builds of Clang and lld from apt.llvm.org and binutils/QEMU for arm, arm64, powerpc, and x86_64.
 
-Currently, this image is available for x86_64 hosts on [Docker Hub](https://hub.docker.com/r/clangbuiltlinux/debian/) (`docker run -ti clangbuiltlinux/debian`), which is updated daily via a Travis cron.
+Currently, this image is available for x86_64 hosts on [Docker Hub](https://hub.docker.com/r/clangbuiltlinux/ubuntu/) (`docker run -ti clangbuiltlinux/ubuntu`), which is updated daily via a Travis cron.
 
 We are thinking of ways to make this image available to other architectures. The biggest blocker is the nightly Clang builds are only for x86.
 


### PR DESCRIPTION
Since moving to Debian unstable, there have been two independent errors
that have manifested during 'apt upgrade/install', resulting in no image
update. This is a little bit too unstable for my liking.  We need these
images to be up to date so we get accurate CI results.

https://travis-ci.com/github/ClangBuiltLinux/dockerimage/jobs/319302223
https://travis-ci.com/github/ClangBuiltLinux/dockerimage/jobs/319714044

We could try to move to Debian testing but it does not have official
support on apt.llvm.org so we risk dependency issues trying to use the
Debian unstable apt.llvm.org repos with a Debian testing base.

Ubuntu Focal gives us QEMU 4.2 (the reason to move to Debian unstable in
the first place) and it is a week away from its official release so we
should not be running into any instability with it. Additionally, it is
an LTS release so hopefully we won't need to move from it for a while.