### PR TITLE
Reformat shell scripts with shfmt and validate in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,29 @@
+# Run shellcheck and shfmt on all shell files in this repository
+name: shell-scripts-codestyle-check
+on: [push, pull_request]
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: shellcheck
+      uses: bewuethr/shellcheck-action@v1
+  shfmt-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.14.2'
+    - uses: actions/cache@v1
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Run shfmt
+      run: |
+        GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
+        while read -r f; do
+          PATH=$HOME/go/bin:$PATH shfmt -ci -d -i 4 $f
+        done < <(find . -type f -name "*.sh")

--- a/scripts/check-binaries.sh
+++ b/scripts/check-binaries.sh
@@ -10,19 +10,19 @@ function test_command() {
     fi
 }
 
-BINARIES=( "clang" "ld.lld" "llvm-ar" "llvm-nm" )
+BINARIES=("clang" "ld.lld" "llvm-ar" "llvm-nm")
 for BINARY in "${BINARIES[@]}"; do
     test_command "${BINARY}-${LLVM_VERSION}"
 done
 
-QEMU_SUFFIXES=( "arm" "aarch64" "i386" "mips" "mipsel" "ppc" "ppc64" "x86_64" )
+QEMU_SUFFIXES=("arm" "aarch64" "i386" "mips" "mipsel" "ppc" "ppc64" "x86_64")
 for QEMU_SUFFIX in "${QEMU_SUFFIXES[@]}"; do
     test_command "qemu-system-${QEMU_SUFFIX}"
 done
 
-BINUTILS_PREFIXES=( "" "aarch64-linux-gnu-" "arm-linux-gnueabi-" "mips-linux-gnu-"
-                    "mipsel-linux-gnu-" "powerpc-linux-gnu-" "powerpc64-linux-gnu-"
-                    "powerpc64le-linux-gnu-" "riscv64-linux-gnu-" "s390x-linux-gnu-" )
+BINUTILS_PREFIXES=("" "aarch64-linux-gnu-" "arm-linux-gnueabi-" "mips-linux-gnu-"
+    "mipsel-linux-gnu-" "powerpc-linux-gnu-" "powerpc64-linux-gnu-"
+    "powerpc64le-linux-gnu-" "riscv64-linux-gnu-" "s390x-linux-gnu-")
 for BINUTILS_PREFIX in "${BINUTILS_PREFIXES[@]}"; do
     test_command "${BINUTILS_PREFIX}as"
 done

--- a/scripts/check-clang.sh
+++ b/scripts/check-clang.sh
@@ -8,7 +8,7 @@ if [[ ${LLVM_VERSION} -eq 11 ]]; then
     # Target: x86_64-pc-linux-gnu
     # Thread model: posix
     # InstalledDir: /usr/bin
-    CLANG_DATE=$(clang-${LLVM_VERSION} --version | head -n1 | cut -d '~' -f 3 | cut -d . -f 1)
+    CLANG_DATE=$(clang-"${LLVM_VERSION}" --version | head -n1 | cut -d '~' -f 3 | cut -d . -f 1)
 
     # Next, we need to parse the date into a format the date binary can understand
     # We use bash substring expansion: https://wiki.bash-hackers.org/syntax/pe#substring_expansion

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -eux
 echo "${DOCKER_PASSWORD}" | docker login -u "${DOCKER_USERNAME}" --password-stdin
-docker push ${REPO}:llvm${LLVM_VERSION:=11}-${DATE}
-docker push ${REPO}:llvm${LLVM_VERSION}-latest
+docker push "${REPO}:llvm${LLVM_VERSION:=11}-${DATE}"
+docker push "${REPO}:llvm${LLVM_VERSION}-latest"
 if [[ ${LLVM_VERSION} -eq 11 ]]; then
-    docker push ${REPO}:latest
+    docker push "${REPO}:latest"
 fi


### PR DESCRIPTION
Uses [mvdan/sh](https://github.com/mvdan/sh) to enable formatting checks in CI, and correctly fails when the codestyle is [incorrect](https://github.com/msfjarvis/boot-utils/actions/runs/85612538), outputting a diff with fixes.

I chose the set of options that made the most sense to me, all available switches are listed [here](https://bin.msfjarvis.dev/~5ea167531de3ad00122e4ec0).
